### PR TITLE
Fix for Bootstrap-3-Typeahead compatibility bug

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -304,6 +304,7 @@
           },
           updater: function (text) {
             self.add(this.map[text]);
+            return this.map[text];
           },
           matcher: function (text) {
             return (text.toLowerCase().indexOf(this.query.trim().toLowerCase()) !== -1);


### PR DESCRIPTION
Bootstrap3-typeahead's `displayText` method expects a value, and bootstrap-tagsinput's `updater` method doesn't seem to provide one. I haven't done extensive testing, but my simple fix (returning the value found in `updater`) seems to fix the issue for me. 

The bug thrown by bootstrap3-typeahead comes from here:
<https://github.com/bassjobsen/Bootstrap-3-Typeahead/blob/master/bootstrap3-typeahead.js#L246>

The specific error I'm seeing: `Uncaught TypeError: Cannot read property 'name' of undefined` (boostrap3-typeahead.js:246)

---

I haven't taken the time to investigate any deeper: is the `self.add` method doing anything important that would affect the return value? It seems to currently return `undefined` so I just assumed it wouldn't affect the typeahead plugin.