### PR TITLE
Changed the open typeahead window check

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -339,7 +339,7 @@
           self.$input.on('focusout', $.proxy(function(event) {
               // HACK: only process on focusout when no typeahead opened, to
               //       avoid adding the typeahead text as tag
-              if ($('.typeahead, .twitter-typeahead', self.$container).length === 0) {
+              if ($('.typeahead, .twitter-typeahead', self.$container).not(':visible')) {
                 self.add(self.$input.val());
                 self.$input.val('');
               }


### PR DESCRIPTION
When a using .length === 0, the add on focusout gets canceled when a typeahead window was previously visible