### PR TITLE
Pass autoselect option to typeahead.js.

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -320,8 +320,8 @@
       // typeahead.js
       if (self.options.typeaheadjs) {
           var typeaheadjs = self.options.typeaheadjs || {};
-
-          self.$input.typeahead(null, typeaheadjs).on('typeahead:selected', $.proxy(function (obj, datum) {
+          var opts = { autoselect: typeaheadjs.autoselect };
+          self.$input.typeahead(opts, typeaheadjs).on('typeahead:selected', $.proxy(function (obj, datum) {
             if (typeaheadjs.valueKey)
               self.add(datum[typeaheadjs.valueKey]);
             else


### PR DESCRIPTION
This option enables the user to press enter to automatically select the closest
matching tag to the text entered. I think that's the intuitive thing to do when enter
is pressed. 

With this change the user can pass a boolean 'autoselect' in the typeaheadjs options object to turn this feature on and off.

Resolves #221 