### PR TITLE
Meteor integration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Install dependencies:
 <pre>
 npm install
 bower install
+// Choose which bootstrap package you want to use. twbs:bootstrap is a popular choice.
+meteor add twbs:bootstrap
+meteor add bootstrp:tagsinput
 </pre>
 Test:
 <pre>

--- a/package.js
+++ b/package.js
@@ -1,0 +1,19 @@
+// package metadata file for Meteor.js
+
+Package.describe({
+  name: 'bootstrp:tagsinput', // https://atmospherejs.com/bootstrp/tagsinput
+  summary: 'Bootstrap Tags Input is a jQuery plugin providing a user interface for managing tags.',
+  version: '0.5.0',
+  git: 'https://github.com/timschlechter/bootstrap-tagsinput.git'
+});
+
+Package.onUse(function (api) {
+  api.versionsFrom('METEOR@1.0');
+
+  api.use('jquery', 'client');
+
+  api.addFiles([
+    'dist/bootstrap-tagsinput.js',
+    'dist/bootstrap-tagsinput.css'
+  ], 'client');
+});


### PR DESCRIPTION
Hello guys,

As you might know, the [Meteor](https://www.meteor.com/) community is widely using
bootstrap-tagsinput. We had many different wrapper packages all doing the same thing,
so I'm submitting a PR that integrates Meteor packaging directly into your repository:
at the end of this merge process, in case you'll find yourself comfortable with it, we'll
get automated new Meteor package releases with every new release of `bootstrap-tagsinput`.

I've made this PR as lean as possible so as not to take up too much space within your
repository: basically it adds only a `package.js` file among the ones already present
for other package managers.

All you have to do after accepting this PR would be:

1. Create an account at https://meteor.com/ (click SIGN IN, then Create account).
After you've done that, please let me know the name of the account, and we'll add you
as a maintainer of the `bootstrp` organization (which has been already
reserved to make things simpler for you).

2. Activate your repo on *autopublish.meteor.com*  
  1. Head to [autopublish.meteor.com](http://autopublish.meteor.com/), sign in with your
     GitHub account, locate this repository and enable it for autopublish by toggling the checkbox
     you'll find on the right side of the repository item. You can get an idea about how Meteor
     Autopublish works on [this page](http://autopublish.meteor.com/howitworks), but basically
     it creates a [web hook](https://help.github.com/articles/about-webhooks/) to let us know
     when you push new tags. When you'll release new versions, autopublish.meteor.com will
     automatically package the the new version of the library also for Meteor!

  2. In case you're not comfortable with autopublish.meteor.com maintaining access rights to
     your repos, please head to [GitHub Application Settings](https://github.com/settings/applications)
     and revoke permissions for *Meteor Autopublish*.

  Please note that you will not be able to toggle your repository until you have the `package.js` file on
  your master branch.

3. Alternatively, in case you're not willing to give read/write rights to your public repositories
to anyone else but you (which is understandable), we will be available to provide a step-by-step
guide to manually creating the required webhook.

Please also note that we've already published the current version of the package on
[Atmosphere](https://atmospherejs.com/bootstrp/tagsinput)
(Meteor's package directory) under the name `bootstrp:tagsinput`. If you think another
name would be a better fit, just let us know!

Thanks in advance for your availability and collaboration and congratulations on the awesome project!

David & the [Meteor Packaging Team](https://github.com/orgs/MeteorPackaging/people)