### PR TITLE
don't focus input box if we clicked on the X button in the tag, helps…

### DIFF
--- a/src/bootstrap-tagsinput.js
+++ b/src/bootstrap-tagsinput.js
@@ -344,7 +344,12 @@
         if (! self.$element.attr('disabled')) {
           self.$input.removeAttr('disabled');
         }
-        self.$input.focus();
+        if (event.toElement.tagName != "SPAN")
+        {
+            // don't focus if clicked on the X button to close tag, makes things 
+            // difficult with typeahead and populating with minSize 0
+            self.$input.focus();
+        }
       }, self));
 
         if (self.options.addOnBlur && self.options.freeInput) {


### PR DESCRIPTION
… with typeahead not reshowing up again and again and stopping us from remove many tags easily